### PR TITLE
Add interpolation for distortions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,20 +121,27 @@ The syntax is the following:
         "global" : {  // category of distortions that should be applied on all the components
                       // the structure of the folders must be organized in the same way as the GERDA PDFs
                       // releases and the name of the histogram must match
-            "distortion-type1" : [  // set the deformation type (not important)
-                "folder1",  // list here the folder names
-                ...
-            ],
+            "distortion-type1" : {  // set the deformation type (not important)
+                "pdfs" : [
+                    "folder1",  // list here the folder names
+                    ...
+                ],
+                "interpolate": true  // can randomly reduce the magnitude of the distortion
+                                     // by mixing it with the unitary distortion
+            },
             ...
         },
         "specific" : {  // category of distortions that have to be applied to single components
-            "component1"  : [ "file1.root" ], // the name of the component must be listed also in the
+            "component1"  : { "pdfs" : [ "file1.root" ] }, // the name of the component must be listed also in the
                                               // list of model components above!
-            "component2"   : [
-                "file2.root:objname",  // single ROOT file with eventual object name
-                "file3.root",
-                ...
-            ]
+            "component2" : {
+                "pdfs" : [
+                    "file2.root:objname",  // single ROOT file with eventual object name
+                    "file3.root",
+                    ...
+                ],
+                "interpolate" : true,
+            }
         }
     }
 ```

--- a/config/phIIAfterLAr-systematics.json
+++ b/config/phIIAfterLAr-systematics.json
@@ -1,5 +1,5 @@
 {
-    "logging" : "info",
+    "logging" : "debug",
     "output" : {
         "file" : "../results/phIIAfterLAr-exp-pool.root",
         "number-of-bins" : 8000,
@@ -98,37 +98,44 @@
     "pdf-distortions" : {
         "prefix" : "../data/distortions",
         "global" : {
-            "LAr-veto-model" : [
-                "gerda-pdfs-2nufit-larmodel-d0p55",
-                "gerda-pdfs-2nufit-larmodel-d0p65",
-                "gerda-pdfs-2nufit-larmodel-d0p75",
-                "gerda-pdfs-2nufit-larmodel-d0p85",
-                "gerda-pdfs-2nufit-larmodel-d0p95",
-                "gerda-pdfs-2nufit-larmodel-d1p05",
-                "gerda-pdfs-2nufit-larmodel-d1p15",
-                "gerda-pdfs-2nufit-larmodel-d1p25",
-                "gerda-pdfs-2nufit-larmodel-d1p35",
-                "gerda-pdfs-2nufit-larmodel-d1p45"
-            ],
-            "transition-layer" : [
-                "gerda-pdfs-2nufit-tlayer-m1sigma",
-                "gerda-pdfs-2nufit-tlayer-m2sigma",
-                "gerda-pdfs-2nufit-tlayer-m5sigma",
-                "gerda-pdfs-2nufit-tlayer-p1sigma",
-                "gerda-pdfs-2nufit-tlayer-p2sigma",
-                "gerda-pdfs-2nufit-tlayer-p5sigma"
-            ]
+            "LAr-veto-model" : {
+                "pdfs" : [
+                    "gerda-pdfs-2nufit-larmodel-d0p50",
+                    "gerda-pdfs-2nufit-larmodel-d0p60",
+                    "gerda-pdfs-2nufit-larmodel-d0p70",
+                    "gerda-pdfs-2nufit-larmodel-d0p80",
+                    "gerda-pdfs-2nufit-larmodel-d0p90",
+                    "gerda-pdfs-2nufit-larmodel-d1p10",
+                    "gerda-pdfs-2nufit-larmodel-d1p20",
+                    "gerda-pdfs-2nufit-larmodel-d1p30",
+                    "gerda-pdfs-2nufit-larmodel-d1p40",
+                    "gerda-pdfs-2nufit-larmodel-d1p50"
+                ]
+            },
+            "transition-layer" : {
+                "pdfs" : [
+                    "gerda-pdfs-2nufit-tlayer-m1sigma",
+                    "gerda-pdfs-2nufit-tlayer-m2sigma",
+                    "gerda-pdfs-2nufit-tlayer-m5sigma",
+                    "gerda-pdfs-2nufit-tlayer-p1sigma",
+                    "gerda-pdfs-2nufit-tlayer-p2sigma",
+                    "gerda-pdfs-2nufit-tlayer-p5sigma"
+                ]
+            }
         },
         "specific" : {
-            "Ac228"       : [ "pdf-Ac228-holders_vs_fibers.root" ],
-            "K40-far"     : [ "pdf-K40_far-cc3_vs_copper_shroud.root" ],
-            "K42-close"   : [ "pdf-K42_close-nplus_bege_vs_pplus_bege.root" ],
-            "K42-far"     : [ "pdf-K42_far-sur_array_vs_above_array.root" ],
-            "Bi212-Tl208" : [ "pdf-Bi212_Tl208-cables_vs_fibers.root" ],
-            "K40-close"   : [
-                "pdf-K40_close-minishroud_vs_cables.root",
-                "pdf-K40_close-minishroud_vs_holders.root"
-            ]
+            "Ac228"       : { "pdfs" : [ "pdf-Ac228-holders_vs_fibers.root" ] },
+            "K40-far"     : { "pdfs" : [ "pdf-K40_far-cc3_vs_copper_shroud.root" ] },
+            "K42-close"   : { "pdfs" : [ "pdf-K42_close-nplus_bege_vs_pplus_bege.root" ] },
+            "K42-far"     : { "pdfs" : [ "pdf-K42_far-sur_array_vs_above_array.root" ] },
+            "Bi212-Tl208" : { "pdfs" : [ "pdf-Bi212_Tl208-cables_vs_fibers.root" ] },
+            "K40-close"   : {
+                "interpolate" : true,
+                "pdfs" : [
+                    "pdf-K40_close-minishroud_vs_cables.root",
+                    "pdf-K40_close-minishroud_vs_holders.root"
+                ]
+            }
         }
     }
 }

--- a/config/phIIAfterLAr-systematics.json
+++ b/config/phIIAfterLAr-systematics.json
@@ -102,15 +102,25 @@
             }
         },
         "specific" : {
-            "Ac228"       : { "pdfs" : [ "pdf-Ac228-holders_vs_fibers.root" ] },
+            "Ac228"       : {
+                "interpolate" : true,
+                "pdfs" : [ "pdf-Ac228-holders_vs_fibers.root" ]
+            },
             "K42-close"   : {
+                "interpolate" : true,
                 "pdfs" : [
                     "pdf-K42_close-inside_ms_vs_nplus_bege.root",
                     "pdf-K42_close-inside_ms_vs_pplus_bege.root"
                 ]
             },
-            "K42-far"     : { "pdfs" : [ "pdf-K42_far-outside_ms_vs_above_array.root" ] },
-            "Bi212-Tl208" : { "pdfs" : [ "pdf-Bi212_Tl208-cables_vs_fibers.root" ] },
+            "K42-far"     : {
+                "interpolate" : true,
+                "pdfs" : [ "pdf-K42_far-outside_ms_vs_above_array.root" ]
+            },
+            "Bi212-Tl208" : {
+                "interpolate" : true,
+                "pdfs" : [ "pdf-Bi212_Tl208-cables_vs_fibers.root" ]
+            },
             "K40-close"   : {
                 "interpolate" : true,
                 "pdfs" : [

--- a/config/phIIAfterLAr-systematics.json
+++ b/config/phIIAfterLAr-systematics.json
@@ -1,5 +1,5 @@
 {
-    "logging" : "debug",
+    "logging" : "info",
     "output" : {
         "file" : "../results/phIIAfterLAr-exp-pool.root",
         "number-of-bins" : 8000,
@@ -10,19 +10,6 @@
     "number-of-experiments" : 100,
     "hist-name" : "lar/M1_enrBEGe",
     "components" : [
-        {
-            "root-file" : "../data/gerda-pdfs/pdf-functions.root",
-            "components" : {
-                "alpha-slope" : {
-                    "hist-name" : "ramp",
-                    "amount-cts" : 0
-                },
-                "alpha-offset" : {
-                    "hist-name" : "flat",
-                    "amount-cts" : 28
-                }
-            }
-        },
         {
             "part": "cables/cables_all",
             "components" : {
@@ -68,16 +55,7 @@
             }
         },
         {
-            "part": "electronics/cc3",
-            "components" : {
-                "K40-far" : {
-                    "isotope" : "K40",
-                    "amount-cts" : 953
-                }
-            }
-        },
-        {
-            "part": "lar/sur_array",
+            "part": "lar/outside_ms",
             "components" : {
                 "K42-far" : {
                     "isotope" : "K42",
@@ -86,7 +64,7 @@
             }
         },
         {
-            "part": "gedet/nplus_bege",
+            "part": "lar/inside_ms",
             "components" : {
                 "K42-close" : {
                     "isotope" : "K42",
@@ -125,15 +103,21 @@
         },
         "specific" : {
             "Ac228"       : { "pdfs" : [ "pdf-Ac228-holders_vs_fibers.root" ] },
-            "K40-far"     : { "pdfs" : [ "pdf-K40_far-cc3_vs_copper_shroud.root" ] },
-            "K42-close"   : { "pdfs" : [ "pdf-K42_close-nplus_bege_vs_pplus_bege.root" ] },
-            "K42-far"     : { "pdfs" : [ "pdf-K42_far-sur_array_vs_above_array.root" ] },
+            "K42-close"   : {
+                "pdfs" : [
+                    "pdf-K42_close-inside_ms_vs_nplus_bege.root",
+                    "pdf-K42_close-inside_ms_vs_pplus_bege.root"
+                ]
+            },
+            "K42-far"     : { "pdfs" : [ "pdf-K42_far-outside_ms_vs_above_array.root" ] },
             "Bi212-Tl208" : { "pdfs" : [ "pdf-Bi212_Tl208-cables_vs_fibers.root" ] },
             "K40-close"   : {
                 "interpolate" : true,
                 "pdfs" : [
                     "pdf-K40_close-minishroud_vs_cables.root",
-                    "pdf-K40_close-minishroud_vs_holders.root"
+                    "pdf-K40_close-minishroud_vs_holders.root",
+                    "pdf-K40_close-minishroud_vs_copper_shroud.root",
+                    "pdf-K40_close-minishroud_vs_cc3.root"
                 ]
             }
         }

--- a/data/compute-distortions
+++ b/data/compute-distortions
@@ -39,22 +39,22 @@ done
     distortions/pdf-Ac228-holders_vs_fibers.root
 
 ./take_ratio.C \
-    gerda-pdfs/gerda-pdfs-2nufit-best/larveto/copper_shroud/K40/pdf-larveto-copper_shroud-K40.root \
-    gerda-pdfs/gerda-pdfs-2nufit-best/electronics/cc3/K40/pdf-electronics-cc3-K40.root \
+    gerda-pdfs/gerda-pdfs-2nufit-best/gedet/nplus_bege/K42/pdf-gedet-nplus_bege-K42.root \
+    gerda-pdfs/gerda-pdfs-2nufit-best/lar/inside_ms/K42/pdf-lar-inside_ms-K42.root \
     lar/M1_enrBEGe lar/M1_enrCoax \
-    distortions/pdf-K40_far-cc3_vs_copper_shroud.root
+    distortions/pdf-K42_close-inside_ms_vs_nplus_bege.root
 
 ./take_ratio.C \
     gerda-pdfs/gerda-pdfs-2nufit-best/gedet/pplus_bege/K42/pdf-gedet-pplus_bege-K42.root \
-    gerda-pdfs/gerda-pdfs-2nufit-best/gedet/nplus_bege/K42/pdf-gedet-nplus_bege-K42.root \
+    gerda-pdfs/gerda-pdfs-2nufit-best/lar/inside_ms/K42/pdf-lar-inside_ms-K42.root \
     lar/M1_enrBEGe lar/M1_enrCoax \
-    distortions/pdf-K42_close-nplus_bege_vs_pplus_bege.root
+    distortions/pdf-K42_close-inside_ms_vs_pplus_bege.root
 
 ./take_ratio.C \
     gerda-pdfs/gerda-pdfs-2nufit-best/lar/above_array/K42/pdf-lar-above_array-K42.root \
-    gerda-pdfs/gerda-pdfs-2nufit-best/lar/sur_array/K42/pdf-lar-sur_array-K42.root \
+    gerda-pdfs/gerda-pdfs-2nufit-best/lar/outside_ms/K42/pdf-lar-outside_ms-K42.root \
     lar/M1_enrBEGe lar/M1_enrCoax \
-    distortions/pdf-K42_far-sur_array_vs_above_array.root
+    distortions/pdf-K42_far-outside_ms_vs_above_array.root
 
 ./take_ratio.C \
     gerda-pdfs/gerda-pdfs-2nufit-best/cables/cables_all/K40/pdf-cables-cables_all-K40.root \
@@ -67,5 +67,17 @@ done
     gerda-pdfs/gerda-pdfs-2nufit-best/minishroud/ms_all/K40/pdf-minishroud-ms_all-K40.root \
     lar/M1_enrBEGe lar/M1_enrCoax \
     distortions/pdf-K40_close-minishroud_vs_holders.root
+
+./take_ratio.C \
+    gerda-pdfs/gerda-pdfs-2nufit-best/larveto/copper_shroud/K40/pdf-larveto-copper_shroud-K40.root \
+    gerda-pdfs/gerda-pdfs-2nufit-best/minishroud/ms_all/K40/pdf-minishroud-ms_all-K40.root \
+    lar/M1_enrBEGe lar/M1_enrCoax \
+    distortions/pdf-K40_close-minishroud_vs_copper_shroud.root
+
+./take_ratio.C \
+    gerda-pdfs/gerda-pdfs-2nufit-best/electronics/cc3/K40/pdf-electronics-cc3-K40.root \
+    gerda-pdfs/gerda-pdfs-2nufit-best/minishroud/ms_all/K40/pdf-minishroud-ms_all-K40.root \
+    lar/M1_enrBEGe lar/M1_enrCoax \
+    distortions/pdf-K40_close-minishroud_vs_cc3.root
 
 ./Bi212Tl208_distortion.C

--- a/src/gerda-factory.cc
+++ b/src/gerda-factory.cc
@@ -146,11 +146,14 @@ int main(int argc, char** argv) {
                             auto weight = rndgen.Uniform(1);
                             logs::out(logs::debug) << "successfully found corresponding fit component '" << itt->name
                                                    << "', distorting with weight = " << weight << std::endl;
-                            result->hist->Scale(weight);
-                            result->hist->Multiply(itt->hist.get());
-                            for (int b = 0; b <= result->hist->GetNbinsX(); ++b) {
-                                result->hist->SetBinContent(b, result->hist->GetBinContent(b) + 1 - weight);
-                            }
+
+                            auto result_tmp = dynamic_cast<TH1*>(result->hist->Clone());
+                            result_tmp->Multiply(itt->hist.get());
+                            result_tmp->Scale(weight/result_tmp->Integral());
+
+                            result->hist->Scale((1-weight)/result->hist->Integral());
+                            result->hist->Add(result_tmp);
+
                             done_something = true;
                         }
                         else {
@@ -246,11 +249,13 @@ int main(int argc, char** argv) {
 
                         auto weight = rndgen.Uniform(1);
                         logs::out(logs::debug) << "distorting with weight = " << weight << std::endl;
-                        result->hist->Scale(weight);
-                        result->hist->Multiply(hdist.get());
-                        for (int b = 0; b <= result->hist->GetNbinsX(); ++b) {
-                            result->hist->SetBinContent(b, result->hist->GetBinContent(b) + 1 - weight);
-                        }
+
+                        auto result_tmp = dynamic_cast<TH1*>(result->hist->Clone());
+                        result_tmp->Multiply(hdist.get());
+                        result_tmp->Scale(weight/result_tmp->Integral());
+
+                        result->hist->Scale((1-weight)/result->hist->Integral());
+                        result->hist->Add(result_tmp);
 
                         done_something = true;
                     }

--- a/src/gerda-factory.cc
+++ b/src/gerda-factory.cc
@@ -117,15 +117,23 @@ int main(int argc, char** argv) {
         if (config["pdf-distortions"]["global"].is_object()) {
             logs::out(logs::detail) << "applying 'global' distortions" << std::endl;
             for (auto& it : config["pdf-distortions"]["global"].items()) {
-                logs::out(logs::debug) << "randomly choosing a distortion for '" << it.key() << std::endl;
-                // choose a distortion randomly
-                // the +1 corresponds to no distortion applied
-                auto choice = rndgen.Integer(it.value().size()+1);
-                if (choice != it.value().size()) {
+
+                bool interpolate = false;
+                if (it.value().contains("interpolate")) {
+                    if (it.value()["interpolate"].get<bool>() == true) interpolate = true;
+                }
+
+                if (interpolate) {
+                    logs::out(logs::debug) << "randomly choosing a distortion for '" << it.key()
+                                           << " and interpolating with the unitary distortion" << std::endl;
+                    // choose a discrete distortion randomly
+                    auto choice = rndgen.Integer(it.value()["pdfs"].size());
                     logs::out(logs::detail) << "chosen random distortion: '"
-                                            << it.value()[choice].get<std::string>() << "'" << std::endl;
+                                            << it.value()["pdfs"][choice].get<std::string>()
+                                            << "'" << (interpolate ? " -> interpolate" : "") << std::endl;
+
                     // get histograms
-                    auto dist_list = utils::get_components_json(config, dist_prefix + it.value()[choice].get<std::string>());
+                    auto dist_list = utils::get_components_json(config, dist_prefix + it.value()["pdfs"][choice].get<std::string>());
                     for (auto itt = dist_list.begin(); itt != dist_list.end(); itt++) {
                         // see if we have a corresponding fit component
                         auto result = std::find_if(
@@ -133,24 +141,62 @@ int main(int argc, char** argv) {
                             [&itt](utils::bkg_comp& a) { return a.name == itt->name; }
                         );
 
-                        // distort
+                        // distort with weight
                         if (result != comp_list.end()) {
+                            auto weight = rndgen.Uniform(1);
                             logs::out(logs::debug) << "successfully found corresponding fit component '" << itt->name
-                                                   << "', distorting" << std::endl;
+                                                   << "', distorting with weight = " << weight << std::endl;
+                            result->hist->Scale(weight);
                             result->hist->Multiply(itt->hist.get());
+                            for (int b = 0; b <= result->hist->GetNbinsX(); ++b) {
+                                result->hist->SetBinContent(b, result->hist->GetBinContent(b) + 1 - weight);
+                            }
                             done_something = true;
                         }
                         else {
                             logs::out(logs::warning) << "could not find component '" << it.key()
-                                                     << "' to distort" << std::endl;
+                                << "' to distort" << std::endl;
                         }
                     }
                 }
-                // no distortion applied
                 else {
-                    logs::out(logs::detail) << "chosen random distortion: "
-                                            << "stay with current PDF" << std::endl;
-                    done_something = true;
+                    logs::out(logs::debug) << "randomly choosing a discrete distortion for '" << it.key() << std::endl;
+                    // choose a distortion randomly
+                    // the +1 corresponds to no distortion applied
+                    auto choice = rndgen.Integer(it.value()["pdfs"].size()+1);
+                    if (choice != it.value()["pdfs"].size()) {
+                        logs::out(logs::detail) << "chosen random distortion: '"
+                                                << it.value()["pdfs"][choice].get<std::string>()
+                                                << "'" << std::endl;
+
+                        // get histograms
+                        auto dist_list = utils::get_components_json(config, dist_prefix + it.value()["pdfs"][choice].get<std::string>());
+                        for (auto itt = dist_list.begin(); itt != dist_list.end(); itt++) {
+                            // see if we have a corresponding fit component
+                            auto result = std::find_if(
+                                    comp_list.begin(), comp_list.end(),
+                                    [&itt](utils::bkg_comp& a) { return a.name == itt->name; }
+                                    );
+
+                            // distort
+                            if (result != comp_list.end()) {
+                                logs::out(logs::debug) << "successfully found corresponding fit component '" << itt->name
+                                    << "', distorting" << std::endl;
+                                result->hist->Multiply(itt->hist.get());
+                                done_something = true;
+                            }
+                            else {
+                                logs::out(logs::warning) << "could not find component '" << it.key()
+                                    << "' to distort" << std::endl;
+                            }
+                        }
+                    }
+                    // no distortion applied
+                    else {
+                        logs::out(logs::detail) << "chosen random distortion: "
+                                                << "stay with current PDF" << std::endl;
+                        done_something = true;
+                    }
                 }
             }
         }
@@ -158,26 +204,75 @@ int main(int argc, char** argv) {
         if (config["pdf-distortions"]["specific"].is_object()) {
             logs::out(logs::detail) << "applying 'specific' distortions" << std::endl;
             for (auto& it : config["pdf-distortions"]["specific"].items()) {
+
                 // see if we have a corresponding fit component
                 auto result = std::find_if(
                     comp_list.begin(), comp_list.end(),
                     [&it](utils::bkg_comp& a) { return a.name == it.key(); }
                 );
 
-                if (result != comp_list.end()) {
+                if (result == comp_list.end()) {
+                    logs::out(logs::warning) << "could not find component '" << it.key()
+                                             << "' to distort" << std::endl;
+                    continue;
+                }
+                else {
                     logs::out(logs::debug) << "successfully found corresponding fit component '" << it.key()
                                            << "'" << std::endl;
-                    logs::out(logs::debug) << "randomly choosing a distortion for '" << it.key() << std::endl;
+                }
+
+                bool interpolate = false;
+                if (it.value().contains("interpolate")) {
+                    if (it.value()["interpolate"].get<bool>() == true) interpolate = true;
+                }
+
+                if (interpolate) {
+
+                    logs::out(logs::debug) << "randomly choosing a discrete distortion for '"
+                                           << it.key() << "and interpolating with the unitary distortion" << std::endl;
+                    // choose a distortion randomly
+                    auto choice = rndgen.Integer(it.value()["pdfs"].size());
+
+                    if (it.value()["pdfs"][choice].is_string()) {
+                        logs::out(logs::detail) << "chosen random distortion: '"
+                                                << it.value()["pdfs"][choice].get<std::string>()
+                                                << "'" << (interpolate ? " -> interpolate" : "") << std::endl;
+
+                        auto hdist = utils::get_component(
+                            dist_prefix + it.value()["pdfs"][choice].get<std::string>(),
+                            config["hist-name"].get<std::string>(),
+                            8000, 0, 8000
+                        );
+
+                        auto weight = rndgen.Uniform(1);
+                        logs::out(logs::debug) << "distorting with weight = " << weight << std::endl;
+                        result->hist->Scale(weight);
+                        result->hist->Multiply(hdist.get());
+                        for (int b = 0; b <= result->hist->GetNbinsX(); ++b) {
+                            result->hist->SetBinContent(b, result->hist->GetBinContent(b) + 1 - weight);
+                        }
+
+                        done_something = true;
+                    }
+                    else {
+                        throw std::runtime_error("elements in arrays of distortions must be strings");
+                    }
+                }
+                else {
+
+                    logs::out(logs::debug) << "randomly choosing a discrete distortion for '"
+                                           << it.key() << std::endl;
                     // choose a distortion randomly
                     // the +1 corresponds to no distortion applied
-                    auto choice = rndgen.Integer(it.value().size()+1);
+                    auto choice = rndgen.Integer(it.value()["pdfs"].size()+1);
 
-                    if (choice != it.value().size()) {
-                        if (it.value()[choice].is_string()) {
+                    if (choice != it.value()["pdfs"].size()) {
+                        if (it.value()["pdfs"][choice].is_string()) {
                             logs::out(logs::detail) << "chosen random distortion: '"
-                                                    << it.value()[choice].get<std::string>() << "'" << std::endl;
+                                                    << it.value()["pdfs"][choice].get<std::string>()
+                                                    << "'" << std::endl;
                             auto hdist = utils::get_component(
-                                dist_prefix + it.value()[choice].get<std::string>(),
+                                dist_prefix + it.value()["pdfs"][choice].get<std::string>(),
                                 config["hist-name"].get<std::string>(),
                                 8000, 0, 8000
                             );
@@ -195,10 +290,6 @@ int main(int argc, char** argv) {
                                                 << "stay with current PDF" << std::endl;
                         done_something = true;
                     }
-                }
-                else {
-                    logs::out(logs::warning) << "could not find component '" << it.key()
-                                             << "' to distort" << std::endl;
                 }
             }
         }


### PR DESCRIPTION
Can now mix the chosen distortion with the unitary distortion according to a uniform distribution:
``` 
PDF * (w * dist + (1 - w) * unity)
```
where `w` is sampled from `TRandom3::Uniform(0, 1)`.

CC @bossioel