### PR TITLE
Additional gaussian uncertainty on component counts

### DIFF
--- a/config/phIIAfterLAr-2nbb-no-systematics.json
+++ b/config/phIIAfterLAr-2nbb-no-systematics.json
@@ -7,7 +7,7 @@
     },
     "range-for-counts" : [560, 2000],
     "gerda-pdfs" : "../data/gerda-pdfs/gerda-pdfs-2nufit-best",
-    "number-of-experiments" : 100,
+    "number-of-experiments" : 100000,
     "hist-name" : "lar/M1_enrBEGe",
     "components" : [
         {
@@ -81,14 +81,5 @@
                 }
             }
         }
-    ],
-    "pdf-distortions" : {
-        "prefix" : "../data/distortions",
-        "specific" : {
-            "Co60"       : {
-                "interpolate" : false,
-                "pdfs" : [ "pdf-unitary-distortion-all.root" ]
-            }
-        }
-    }
+    ]
 }


### PR DESCRIPTION
Add possibility to assign uncertainty on the mean counts to draw from component:
```js
"amount-cts-smearing" : [
    {
        "components" : [ "2nbb", "0nbbM1" ], // correlated uncertainties!
        "smearing-percent" : 2.0
    }
],
```

CC @bossioel 