### PR TITLE
Memory management improvements

### DIFF
--- a/src/GerdaFactory.cc
+++ b/src/GerdaFactory.cc
@@ -10,6 +10,8 @@
 GerdaFactory::GerdaFactory() :
     _rndgen(0),
     _range(0, 0) {
+
+    TH1::AddDirectory(false);
 }
 
 void GerdaFactory::SetCountsRange(float xmin, float xmax) {
@@ -25,10 +27,7 @@ void GerdaFactory::AddComponent(const TH1* hist, const float counts) {
 
     // insert clone
     std::unique_ptr<TH1> _tmp(dynamic_cast<TH1*>(hist->Clone(("comp_" + std::to_string(_comp_list.size())).c_str())));
-    auto position = _comp_list.emplace(std::move(_tmp), counts);
-
-    // precaution, detach from any TDirectory
-    position.first->first->SetDirectory(nullptr);
+    _comp_list.emplace(std::move(_tmp), counts);
 }
 
 // creates an internal copy of the histogram pointer

--- a/src/GerdaFactory.h
+++ b/src/GerdaFactory.h
@@ -4,15 +4,15 @@
  * Created: Tue 18 Jun 2019
  *
  */
+#ifndef _GERDA_FACTORY_H
+#define _GERDA_FACTORY_H
+
 #include <vector>
 #include <map>
 #include <memory>
 
 #include "TH1.h"
 #include "TRandom3.h"
-
-#ifndef _GERDA_FACTORY_H
-#define _GERDA_FACTORY_H
 
 class GerdaFactory {
 

--- a/src/GerdaFastFactory.h
+++ b/src/GerdaFastFactory.h
@@ -4,13 +4,14 @@
  * Created: Tue 18 Jun 2019
  *
  */
+#ifndef _GERDA_FAST_FACTORY_H
+#define _GERDA_FAST_FACTORY_H
+
 #include <vector>
+#include <memory>
 
 #include "TH1.h"
 #include "TRandom3.h"
-
-#ifndef _GERDA_FAST_FACTORY_H
-#define _GERDA_FAST_FACTORY_H
 
 class GerdaFastFactory {
 
@@ -22,20 +23,20 @@ class GerdaFastFactory {
 
     // custom constructor
     GerdaFastFactory();
-    ~GerdaFastFactory();
+    ~GerdaFastFactory() = default;
 
-    inline TH1* GetModel() const { return _model; }
+    inline TH1* GetModel() const { return _model.get(); }
 
     void SetCountsRange(float xmin, float xmax);
     void AddComponent(const TH1* hist, const float counts);
     void AddComponent(const std::unique_ptr<TH1>& hist, const float counts);
-    TH1* FillPseudoExp();
+    std::unique_ptr<TH1> FillPseudoExp();
     void ResetComponents();
 
     private:
 
     TRandom3 _rndgen;
-    TH1* _model;
+    std::unique_ptr<TH1> _model;
     std::pair<float, float> _range;
 };
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -44,6 +44,9 @@ namespace utils {
 
     // The returned raw TH1 pointer is owned by the user
     std::unique_ptr<TH1> get_component(std::string filename, std::string objectname, int nbinsx = 100, double xmin = 0, double xmax = 100) {
+
+        TH1::AddDirectory(false);
+
         TFile _tf(filename.c_str());
         if (!_tf.IsOpen()) throw std::runtime_error("invalid ROOT file: " + filename);
         auto obj = _tf.Get(objectname.c_str());
@@ -63,7 +66,6 @@ namespace utils {
             long long int nprim = (_nprim) ? _nprim->GetVal() : 1;
             _th->Scale(1./nprim);
 
-            _th->SetDirectory(nullptr);
             return _th; // expect compiler to copy-elide here
         }
         else if (obj->InheritsFrom(TF1::Class())) {
@@ -71,7 +73,6 @@ namespace utils {
             for (int b = 1; b <= _th->GetNbinsX(); ++b) {
                 _th->SetBinContent(b, dynamic_cast<TF1*>(obj)->Eval(_th->GetBinCenter(b)));
             }
-            _th->SetDirectory(nullptr); // just to be sure
             return _th; // expect compiler to copy-elide here
         }
         else {
@@ -207,9 +208,9 @@ namespace utils {
                         th->SetName((iso.key() + "_" + std::string(th->GetName())).c_str());
 
                         for (int b = 0; b <= th->GetNbinsX()+1; ++b) {
-                            logging::out(logging::warning) << "Negative bin contents detected in pdf built for "
-                                << iso.key() << ", setting them to zero" << std::endl;
                             if (th->GetBinContent(b) < 0) {
+                                logging::out(logging::warning) << "Negative bin content detected in pdf built for "
+                                    << iso.key() << "in bin " << b << ", setting it to zero" << std::endl;
                                 th->SetBinContent(b, 0);
                             }
                         }
@@ -244,8 +245,8 @@ namespace utils {
                         // check for negative bin contents
                         for (int b = 0; b <= collection[0]->GetNbinsX()+1; ++b) {
                             if (collection[0]->GetBinContent(b) < 0) {
-                                logging::out(logging::warning) << "Negative bin contents detected in pdf built for "
-                                    << iso.key() << ", setting them to zero" << std::endl;
+                                logging::out(logging::warning) << "Negative bin content detected in pdf built for "
+                                    << iso.key() << "in bin " << b << ", setting it to zero" << std::endl;
                                 collection[0]->SetBinContent(b, 0);
                             }
                         }


### PR DESCRIPTION
It's getting better with this PR (god bless smart pointers), still there's a small memory leak I cannot fix. Here's the relevant Valgrind output, which seems to blame ROOT (but that's difficult to believe).

```console
$ valgrind --leak-check=full --suppressions=/etc/root/valgrind-root.supp ../bin/gerda-factory phIIAfterLAr-2nbb-all-systematics.json
==707858== Memcheck, a memory error detector
==707858== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==707858== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==707858== Command: ../bin/gerda-factory phIIAfterLAr-2nbb-all-systematics.json
==707858==
...
==707858==
==707858== 11,374,736 (95,000 direct, 11,279,736 indirect) bytes in 95 blocks are definitely lost in loss record 10,617 of 10,617
==707858==    at 0x483ADEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==707858==    by 0x4A5600A: TStorage::ObjectAlloc(unsigned long) (in /usr/lib/root/libCore.so)
==707858==    by 0x54C332A: ??? (in /usr/lib/root/libHist.so)
==707858==    by 0x53DAD73: TH1::Clone(char const*) const (in /usr/lib/root/libHist.so)
==707858==    by 0x135780: GerdaFastFactory::AddComponent(TH1 const*, float) (GerdaFastFactory.cc:37)
==707858==    by 0x11614A: main (gerda-factory.cc:307)
==707858==
==707858== LEAK SUMMARY:
==707858==    definitely lost: 95,016 bytes in 96 blocks
==707858==    indirectly lost: 11,279,736 bytes in 366 blocks
==707858==      possibly lost: 21,721,447 bytes in 9,769 blocks
==707858==    still reachable: 2,372,866 bytes in 21,252 blocks
==707858==                       of which reachable via heuristic:
==707858==                         newarray           : 24,952 bytes in 39 blocks
==707858==                         multipleinheritance: 31,072 bytes in 3 blocks
==707858==         suppressed: 84,811 bytes in 828 blocks
==707858== Reachable blocks (those to which a pointer was found) are not shown.
==707858== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==707858==
==707858== For lists of detected and suppressed errors, rerun with: -s
==707858== ERROR SUMMARY: 1036 errors from 1036 contexts (suppressed: 51693 from 274)
```